### PR TITLE
Fixes value returned from void function.

### DIFF
--- a/entityplus/entity.h
+++ b/entityplus/entity.h
@@ -248,7 +248,7 @@ public:
 	}
 
 	void set_max_linear_dist(std::size_t maxLinearDist) {
-		return maxLinearSearchDistance = maxLinearDist;
+		maxLinearSearchDistance = maxLinearDist;
 	}
 
 	template <typename... Events>


### PR DESCRIPTION
Fixes a compile error caused by returning a non-void value from a
function that is declared with a return type of void.